### PR TITLE
Explicitly add NULL for repeat_instance arg position in redcap_save_record hook call

### DIFF
--- a/AutoRecordGenerationExternalModule.php
+++ b/AutoRecordGenerationExternalModule.php
@@ -272,7 +272,17 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 
 						## Prevent module errors from crashing the whole import process
 						try {
-							ExternalModules::callHook("redcap_save_record",[$_GET['pid'],$_GET['id'],NULL,$targetProject->firstEventId,NULL,NULL,NULL,NULL]);
+							$redcap_save_record_args = [
+								/* $project_id = */ $_GET['pid'],
+								/* $record = */ $_GET['id'],
+								/* $instrument = */ NULL,
+								/* $event_id = */ $targetProject->firstEventId,
+								/* $group_id = */ NULL,
+								/* $survey_hash = */ NULL,
+								/* $response_id = */ NULL,
+								/* $repeat_instance = */ NULL
+							];
+							ExternalModules::callHook("redcap_save_record", $redcap_save_record_args);
 						}
 						catch(\Exception $e) {
 							error_log("External Module Error - Project: ".$_GET['pid']." - Record: ".$_GET['id'].": ".$e->getMessage());

--- a/AutoRecordGenerationExternalModule.php
+++ b/AutoRecordGenerationExternalModule.php
@@ -271,6 +271,8 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 						$_GET['id'] = $dataToPipe[$targetProject->table_pk];
 
 						## Prevent module errors from crashing the whole import process
+						## NOTE: this does NOT catch errors thrown while the target module's redcap_save_record hook is running;
+						## errors from the target module will be handled as if the target module itself were running
 						try {
 							$redcap_save_record_args = [
 								/* $project_id = */ $_GET['pid'],

--- a/AutoRecordGenerationExternalModule.php
+++ b/AutoRecordGenerationExternalModule.php
@@ -272,7 +272,7 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 
 						## Prevent module errors from crashing the whole import process
 						try {
-							ExternalModules::callHook("redcap_save_record",[$_GET['pid'],$_GET['id'],NULL,$targetProject->firstEventId,NULL,NULL,NULL]);
+							ExternalModules::callHook("redcap_save_record",[$_GET['pid'],$_GET['id'],NULL,$targetProject->firstEventId,NULL,NULL,NULL,NULL]);
 						}
 						catch(\Exception $e) {
 							error_log("External Module Error - Project: ".$_GET['pid']." - Record: ".$_GET['id'].": ".$e->getMessage());


### PR DESCRIPTION
Prevents `ArgumentCountError` when triggering hook on EMs that don't set a default value for `$repeat_instance` in their definition of `redcap_save_record`.