### PR TITLE
Use target project's Proj object when calling save_record hook

### DIFF
--- a/AutoRecordGenerationExternalModule.php
+++ b/AutoRecordGenerationExternalModule.php
@@ -261,14 +261,19 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
                     }
 					$target_project_index = array_search($targetProjectID, $this->getProjectSetting("destination_project"));
 					if ($this->getProjectSetting("trigger_save_hook_flag")[$target_project_index] === true) {
+						global $Proj;
 						## Call the save record hook on the new record
 						# Cache get params to reset later
 						$oldId = $_GET['id'];
 						$oldPid = $_GET['pid'];
+						$oldProj = $Proj;
 
 						## Set the $_GET parameter to avoid errors / source project being affected
 						$_GET['pid'] = $targetProjectID;
 						$_GET['id'] = $dataToPipe[$targetProject->table_pk];
+						$Proj = $targetProject;
+
+						$target_record_id = array_keys($dataToPipe)[0];
 
 						## Prevent module errors from crashing the whole import process
 						## NOTE: this does NOT catch errors thrown while the target module's redcap_save_record hook is running;
@@ -276,7 +281,7 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 						try {
 							$redcap_save_record_args = [
 								/* $project_id = */ $_GET['pid'],
-								/* $record = */ $_GET['id'],
+								/* $record = */ $target_record_id,
 								/* $instrument = */ NULL,
 								/* $event_id = */ $targetProject->firstEventId,
 								/* $group_id = */ NULL,
@@ -292,6 +297,7 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 
 						$_GET['id'] = $oldId;
 						$_GET['pid'] = $oldPid;
+						$Proj = $oldProj;
 					}
                 }
             }

--- a/AutoRecordGenerationExternalModule.php
+++ b/AutoRecordGenerationExternalModule.php
@@ -270,10 +270,8 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 
 						## Set the $_GET parameter to avoid errors / source project being affected
 						$_GET['pid'] = $targetProjectID;
-						$_GET['id'] = $dataToPipe[$targetProject->table_pk];
+						$_GET['id'] = array_keys($dataToPipe)[0];
 						$Proj = $targetProject;
-
-						$target_record_id = array_keys($dataToPipe)[0];
 
 						## Prevent module errors from crashing the whole import process
 						## NOTE: this does NOT catch errors thrown while the target module's redcap_save_record hook is running;
@@ -281,7 +279,7 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 						try {
 							$redcap_save_record_args = [
 								/* $project_id = */ $_GET['pid'],
-								/* $record = */ $target_record_id,
+								/* $record = */ $_GET['id'],
 								/* $instrument = */ NULL,
 								/* $event_id = */ $targetProject->firstEventId,
 								/* $group_id = */ NULL,


### PR DESCRIPTION
Also use target project's target record as record param when calling save_record hook

These changes are motivated to ensure interoperability with the Auto DAGs Module. I'm calling them out here so you can correct any assumptions that wouldn't apply in a general sense.

---
## `$target_record_id`

`$target_record_id` is needed to ensure that `$data` is pulled for the correct record:

https://github.com/vanderbilt-redcap/auto-dags-module/blob/7f2c98d89a010775ab5ce526a05c5d4ef52f6d21/AutoDAGsExternalModule.php#L25

IMO, the old `$_GET['id'] = $dataToPipe[$targetProject->table_pk]` setting doesn't actually make much sense with how `$dataToPipe` is formatted anyway since it would always be `null`

```php
$dataToPipe = [
  $target_record_id => [
    $first_event_id => [
      "field_name" => "field_value",
      ...
    ]
  ]
]
```

---
## Emulation of target project's `$Proj` object

`$Proj` needs to emulate the target project to ensure `REDCap::getGroupNames` enumerates the groups in the target project. Without emulating being in the target project, this call returns whatever the ARG module's project's DAGs are, usually resulting in duplication of DAGs in the target project.

https://github.com/vanderbilt-redcap/auto-dags-module/blob/7f2c98d89a010775ab5ce526a05c5d4ef52f6d21/AutoDAGsExternalModule.php#L55


This should rectify any issues where the target project's modules operate on the `$Proj` object, though I'm not sure how y'all feel about overriding that global object if only temporarily; on that note, my only trepidation is that since the try-catch block doesn't catch error spawned by the target project's modules, the `$Proj` object won't be reset to `$oldProj` (which shouldn't matter too much since the rest of the ARG module shouldn't execute, and the problem would be rooted in the module whose `redcap_save_record` hook was called anyway).