### PR TITLE
Update Repeat Instance argument to default value

### DIFF
--- a/AutoRecordGenerationExternalModule.php
+++ b/AutoRecordGenerationExternalModule.php
@@ -285,7 +285,7 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 								/* $group_id = */ NULL,
 								/* $survey_hash = */ NULL,
 								/* $response_id = */ NULL,
-								/* $repeat_instance = */ NULL
+								/* $repeat_instance = */ 1
 							];
 							ExternalModules::callHook("redcap_save_record", $redcap_save_record_args);
 						}

--- a/AutoRecordGenerationExternalModule.php
+++ b/AutoRecordGenerationExternalModule.php
@@ -285,7 +285,7 @@ class AutoRecordGenerationExternalModule extends AbstractExternalModule
 								/* $group_id = */ NULL,
 								/* $survey_hash = */ NULL,
 								/* $response_id = */ NULL,
-								/* $repeat_instance = */ 1
+								/* $repeat_instance = */ $repeat_instance
 							];
 							ExternalModules::callHook("redcap_save_record", $redcap_save_record_args);
 						}


### PR DESCRIPTION
I am working on another module that uses `\REDCap::evaluateLogic` inside of a `redcap_save_record` hook, and passing in the `$repeat_instance = null` causes `\REDCap::evaluateLogic` to return null.  Given that the documentation defaults this value to 1, I think we should pass the default value, as opposed to NULL.  